### PR TITLE
bs-jest should be a dev dependency

### DIFF
--- a/bs-react-spring/bsconfig.json
+++ b/bs-react-spring/bsconfig.json
@@ -18,6 +18,7 @@
       "in-source": true
     }
   ],
-  "bs-dependencies": ["@glennsl/bs-jest", "reason-react"],
+  "bs-dependencies": ["reason-react"],
+  "bs-dev-dependencies": ["@glennsl/bs-jest"],
   "refmt": 3
 }


### PR DESCRIPTION
This fixes "Error: package @glennsl/bs-jest not found or built" for projects that may not have bs-jest installed at the top level.